### PR TITLE
Fix freebusy return value

### DIFF
--- a/lib/automate/google.py
+++ b/lib/automate/google.py
@@ -93,16 +93,16 @@ class Calendar:
             return []
 
         # Parse Time
-        start_time = start.isoformat() + "Z"  # 'Z' indicates UTC time
-        end_time = end.isoformat() + "Z"
+        start_time = start.astimezone().isoformat()  # system timezone
+        end_time = end.astimezone().isoformat()  # system timezone
         to_items = [{"id": email} for email in attendees_email]
         freebusy = (
             self.service.freebusy()
             .query(body={"items": to_items, "timeMin": start_time, "timeMax": end_time})
             .execute()
         )
-        freebusy = map(lambda x: x[0], filter(lambda x: x[1]["busy"], freebusy["calendars"].items()))
-        return list(freebusy)
+        freebusy = list(map(lambda x: x[0], filter(lambda x: x[1]["busy"], freebusy["calendars"].items())))
+        return freebusy
 
     def get_events(self):
         """

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -74,7 +74,7 @@ class Schedule(Module):
         )
 
         # Check if we are busy
-        me_busy = calendar.freebusy(self.when["start"], self.when["end"], ["primary"])
+        me_busy = self.calendar.freebusy(self.when["start"], self.when["end"], ["primary"])
         to_busy = calendar.freebusy(self.when["start"], self.when["end"], to)
         other = f"{', '.join(to_busy[:-1])} and {to_busy[-1]}" if len(to_busy) > 1 else "".join(to_busy)
         if me_busy and to_busy:


### PR DESCRIPTION
# Proposed changes
* Changed the return method of the freebusy query result
* Adjusted the timezone of the queries to the systems local timezone

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Should be able to inform you the user that they are busy when scheduling a meeting 

# Related issue
Fixes #143 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
