### PR TITLE
fix crash when no contacts exists in the contact book

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -35,7 +35,12 @@ def load_local_contacts():
     old_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     with open("../config/contacts.yaml", "r") as stream:
-        SETTINGS["contacts"] = yaml.safe_load(stream)
+        contacts = yaml.safe_load(stream)
+        if contacts:
+            SETTINGS["contacts"] = contacts
+        else:
+            SETTINGS["contacts"] = {}
+
     os.chdir(old_dir)
 
 

--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -37,7 +37,11 @@ def get_emails(names, sender=None):
             emails.append(name)
             continue
 
-        matches = fuzzy.extractBests(name, SETTINGS["contacts"].keys(), score_cutoff=MIN_SCORE)
+        if SETTINGS["contacts"]:
+            matches = fuzzy.extractBests(name, SETTINGS["contacts"].keys(), score_cutoff=MIN_SCORE)
+        else:
+            matches = []
+
         # If the matches contains exact matches, discard the others
         exact_matches = list(filter(lambda match: match[1] == 100, matches))
         if len(exact_matches):


### PR DESCRIPTION
# Proposed changes
* Fix so that the program still works even if there are no contacts in the contact book


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
- Remove all contacts from the local contact book, try to run the program

# Related issue


# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
